### PR TITLE
feat: noparse mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ If you're catering for Windows users that do not use Bash then you might need to
 npx cross-env npm_config_registry=https://registry.npmjs.org npx azdo-npm-auth
 ```
 
+### "No parse"-mode / manually supplying `organization`, `project`, and `feed`
+
+If you would like to manually supply the `organization`, `project`, and `feed` values, you can do so. In this mode of operation `azdo-npm-auth` will not attempt to parse the `.npmrc` file, and will use the supplied values to build a user `.npmrc` file.
+
+If your feed is project-scoped, you will need to supply the `project` value:
+
+```shell
+npm_config_registry=https://registry.npmjs.org npx azdo-npm-auth --organization johnnyreilly --project my-project --feed project-feed-name
+```
+
+If your feed is organization-scoped, you will **not** need to supply the `project` value:
+
+```shell
+npm_config_registry=https://registry.npmjs.org npx azdo-npm-auth --organization johnnyreilly --feed organization-feed-name
+```
+
 ## Integration with `package.json`
 
 ### Custom npm script
@@ -114,6 +130,12 @@ There is an official package named [`ado-npm-auth`](https://github.com/microsoft
 ## Options
 
 `-c` | `--config` (`string`): The location of the .npmrc file. Defaults to current directory
+
+`-o` | `--organization` (`string`): The Azure DevOps organization - only required if not parsing from the .npmrc file
+
+`-r` | `--project` (`string`): The Azure DevOps project - only required if not parsing from the .npmrc file and the feed is project-scoped
+
+`-f` | `--feed` (`string`): The Azure Artifacts feed - only required if not parsing from the .npmrc file
 
 `-e` | `--email` (`string`): Allows users to supply an explicit email - if not supplied, the example ADO value will be used
 

--- a/src/bin/help.test.ts
+++ b/src/bin/help.test.ts
@@ -56,6 +56,18 @@ describe("logHelpText", () => {
 			  ],
 			  [
 			    "
+			  -o | --organization (string): The Azure DevOps organization - only required if not parsing from the .npmrc file",
+			  ],
+			  [
+			    "
+			  -r | --project (string): The Azure DevOps project - only required if not parsing from the .npmrc file and the feed is project-scoped",
+			  ],
+			  [
+			    "
+			  -f | --feed (string): The Azure Artifacts feed - only required if not parsing from the .npmrc file",
+			  ],
+			  [
+			    "
 			  -e | --email (string): Allows users to supply an explicit email - if not supplied, the example ADO value will be used",
 			  ],
 			  [

--- a/src/createUserNpmrc.ts
+++ b/src/createUserNpmrc.ts
@@ -1,5 +1,5 @@
-import type { ParsedProjectNpmrc } from "./parseProjectNpmrc.js";
 import type { Logger } from "./shared/cli/logger.js";
+import type { ParsedProjectNpmrc } from "./types.js";
 
 /**
  * Make a user .npmrc file that looks a little like this:
@@ -26,8 +26,11 @@ export function createUserNpmrc({
 }): string {
 	const base64EncodedPAT = Buffer.from(pat).toString("base64");
 
-	const { urlWithoutRegistryAtEnd, urlWithoutRegistryAtStart, organisation } =
-		parsedProjectNpmrc;
+	const {
+		urlWithoutRegistryAtEnd,
+		urlWithoutRegistryAtStart,
+		organization: organisation,
+	} = parsedProjectNpmrc;
 
 	const npmrc = `; begin auth token
 ${urlWithoutRegistryAtStart}:username=${organisation}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./createPat.js";
 export * from "./createUserNpmrc.js";
+export * from "./makeParsedProjectNpmrc.js";
 export * from "./parseProjectNpmrc.js";
 export * from "./types.js";
 export * from "./writeNpmrc.js";

--- a/src/makeParsedProjectNpmrc.test.ts
+++ b/src/makeParsedProjectNpmrc.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { makeParsedProjectNpmrc } from "./makeParsedProjectNpmrc.js";
+
+describe("makeParsedProjectNpmrc", () => {
+	it("given no project it constructs an organisation feed ParsedProjectNpmrc", () => {
+		const result = makeParsedProjectNpmrc({
+			organization: "johnnyreilly",
+			feed: "npmrc-script-organization",
+		});
+		expect(result).toEqual({
+			organization: "johnnyreilly",
+			urlWithoutRegistryAtEnd:
+				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
+			urlWithoutRegistryAtStart:
+				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+		});
+	});
+
+	it("given a project it constructs a project feed ParsedProjectNpmrc", () => {
+		const result = makeParsedProjectNpmrc({
+			organization: "johnnyreilly",
+			project: "azure-static-web-apps",
+			feed: "npmrc-script-demo",
+		});
+		expect(result).toEqual({
+			organization: "johnnyreilly",
+			urlWithoutRegistryAtEnd:
+				"//pkgs.dev.azure.com/johnnyreilly/azure-static-web-apps/_packaging/npmrc-script-demo/npm/",
+			urlWithoutRegistryAtStart:
+				"//pkgs.dev.azure.com/johnnyreilly/azure-static-web-apps/_packaging/npmrc-script-demo/npm/registry/",
+		});
+	});
+});

--- a/src/makeParsedProjectNpmrc.ts
+++ b/src/makeParsedProjectNpmrc.ts
@@ -1,0 +1,38 @@
+import type { ParsedProjectNpmrc } from "./types.js";
+
+import { fallbackLogger, type Logger } from "./shared/cli/logger.js";
+
+/**
+ * Construct a ParsedProjectNpmrc object using the provided parameters
+ */
+export function makeParsedProjectNpmrc({
+	organization,
+	project,
+	feed,
+	logger = fallbackLogger,
+}: {
+	organization: string;
+	project?: string | undefined;
+	feed: string;
+	logger?: Logger;
+}): ParsedProjectNpmrc {
+	const urlWithoutRegistryAtEnd = project
+		? `//pkgs.dev.azure.com/${organization}/${project}/_packaging/${feed}/npm/`
+		: `//pkgs.dev.azure.com/${organization}/_packaging/${feed}/npm/`;
+
+	const urlWithoutRegistryAtStart = project
+		? `//pkgs.dev.azure.com/${organization}/${project}/_packaging/${feed}/npm/registry/`
+		: `//pkgs.dev.azure.com/${organization}/_packaging/${feed}/npm/registry/`;
+
+	// eg
+	// organization: "johnnyreilly",
+	// urlWithoutRegistryAtEnd: "//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
+	// urlWithoutRegistryAtStart: "//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+
+	logger.info(`Made: 
+- organization: ${organization}
+- urlWithoutRegistryAtStart: ${urlWithoutRegistryAtStart}
+- urlWithoutRegistryAtEnd: ${urlWithoutRegistryAtEnd}`);
+
+	return { urlWithoutRegistryAtStart, urlWithoutRegistryAtEnd, organization };
+}

--- a/src/parseProjectNpmrc.test.ts
+++ b/src/parseProjectNpmrc.test.ts
@@ -9,7 +9,10 @@ vi.mock("./shared/readFileSafe.js", () => ({
 		return mockReadFile;
 	},
 }));
+/*
 
+always-auth=true
+ */
 describe("parseProjectNpmrc", () => {
 	it("outputs the expected structure on successful parse", async () => {
 		mockReadFile.mockResolvedValue(`registry=https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/ 
@@ -19,7 +22,23 @@ always-auth=true`);
 			npmrcPath: "/home/john/code/github/azdo-npm-auth/.npmrc",
 		});
 		expect(result).toEqual({
-			organisation: "johnnyreilly",
+			organization: "johnnyreilly",
+			urlWithoutRegistryAtEnd:
+				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
+			urlWithoutRegistryAtStart:
+				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+		});
+	});
+
+	it("outputs the expected structure when expected last `/` is not there", async () => {
+		mockReadFile.mockResolvedValue(`registry=https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry 
+                        
+always-auth=true`);
+		const result = await parseProjectNpmrc({
+			npmrcPath: "/home/john/code/github/azdo-npm-auth/.npmrc",
+		});
+		expect(result).toEqual({
+			organization: "johnnyreilly",
 			urlWithoutRegistryAtEnd:
 				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
 			urlWithoutRegistryAtStart:

--- a/src/parseProjectNpmrc.test.ts
+++ b/src/parseProjectNpmrc.test.ts
@@ -9,10 +9,7 @@ vi.mock("./shared/readFileSafe.js", () => ({
 		return mockReadFile;
 	},
 }));
-/*
 
-always-auth=true
- */
 describe("parseProjectNpmrc", () => {
 	it("outputs the expected structure on successful parse", async () => {
 		mockReadFile.mockResolvedValue(`registry=https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/ 

--- a/src/parseProjectNpmrc.test.ts
+++ b/src/parseProjectNpmrc.test.ts
@@ -30,7 +30,8 @@ always-auth=true`);
 		});
 	});
 
-	it("outputs the expected structure when expected last `/` is not there", async () => {
+	// I haven't worked out whether I want to support this yet
+	it.skip("outputs the expected structure when expected last `/` is not there", async () => {
 		mockReadFile.mockResolvedValue(`registry=https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry 
                         
 always-auth=true`);

--- a/src/parseProjectNpmrc.ts
+++ b/src/parseProjectNpmrc.ts
@@ -1,11 +1,7 @@
+import type { ParsedProjectNpmrc } from "./types.js";
+
 import { fallbackLogger, type Logger } from "./shared/cli/logger.js";
 import { readFileSafe } from "./shared/readFileSafe.js";
-
-export interface ParsedProjectNpmrc {
-	organisation: string;
-	urlWithoutRegistryAtEnd: string;
-	urlWithoutRegistryAtStart: string;
-}
 
 /**
  * Read the project .npmrc file to acquire necessary info
@@ -49,5 +45,9 @@ export async function parseProjectNpmrc({
 - urlWithoutRegistryAtStart: ${urlWithoutRegistryAtStart}
 - urlWithoutRegistryAtEnd: ${urlWithoutRegistryAtEnd}`);
 
-	return { urlWithoutRegistryAtStart, urlWithoutRegistryAtEnd, organisation };
+	return {
+		urlWithoutRegistryAtStart,
+		urlWithoutRegistryAtEnd,
+		organization: organisation,
+	};
 }

--- a/src/shared/options/args.ts
+++ b/src/shared/options/args.ts
@@ -4,6 +4,21 @@ export const options = {
 		type: "string",
 	},
 
+	organization: {
+		short: "o",
+		type: "string",
+	},
+
+	project: {
+		short: "r",
+		type: "string",
+	},
+
+	feed: {
+		short: "f",
+		type: "string",
+	},
+
 	email: {
 		short: "e",
 		type: "string",
@@ -47,6 +62,27 @@ export const allArgOptions: Record<ValidOption, DocOption> = {
 		...options.config,
 		description:
 			"The location of the .npmrc file. Defaults to current directory",
+		docsSection: "optional",
+	},
+
+	organization: {
+		...options.organization,
+		description:
+			"The Azure DevOps organization - only required if not parsing from the .npmrc file",
+		docsSection: "optional",
+	},
+
+	project: {
+		...options.project,
+		description:
+			"The Azure DevOps project - only required if not parsing from the .npmrc file and the feed is project-scoped",
+		docsSection: "optional",
+	},
+
+	feed: {
+		...options.feed,
+		description:
+			"The Azure Artifacts feed - only required if not parsing from the .npmrc file",
 		docsSection: "optional",
 	},
 

--- a/src/shared/options/optionsSchema.ts
+++ b/src/shared/options/optionsSchema.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 export const optionsSchema = z.object({
 	pat: z.string().optional(),
 	config: z.string().optional(),
+
+	// registry=https://pkgs.dev.azure.com/[ORGANIZATION]/[PROJECT]/_packaging/[FEED_NAME]/npm/registry/
+	organization: z.string().optional(),
+	project: z.string().optional(),
+	feed: z.string().optional(),
+
 	email: z.string().optional(),
 	daysToExpiry: z.number().optional(),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,9 @@ export interface TokenResult {
 	};
 	patTokenError: string;
 }
+
+export interface ParsedProjectNpmrc {
+	organization: string;
+	urlWithoutRegistryAtEnd: string;
+	urlWithoutRegistryAtStart: string;
+}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to azdo-npm-auth! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #18
- [x] That issue was marked as [`status: accepting prs`](https://github.com/johnnyreilly/azdo-npm-auth/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/johnnyreilly/azdo-npm-auth/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR adds a "no parse" mode for when an `.npmrc` is not available
