### PR TITLE
feat: cater for multiple registry entries in a .npmrc file

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 After [forking the repo from GitHub](https://help.github.com/articles/fork-a-repo) and [installing pnpm](https://pnpm.io/installation):
 
 ```shell
-git clone https://github.com/ < your-name-here > /azdo-npm-auth
+git clone https://github.com/johnnyreilly/azdo-npm-auth
 cd azdo-npm-auth
 pnpm install
 ```
@@ -23,6 +23,14 @@ Add `--watch` to run the builder in a watch mode that continuously cleans and re
 
 ```shell
 pnpm build --watch
+```
+
+## Test local build
+
+To try out the local build with a specific package, you can use the `--config` flag to specify the path to the package's `.npmrc` file:
+
+```bash
+pnpm start --config PATH_TO_PACKAGE/.npmrc
 ```
 
 ## Formatting

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ There is an official package named [`ado-npm-auth`](https://github.com/microsoft
 | `-e`  | `--email`        | `string` | Allows users to supply an explicit email - if not supplied, the example ADO value will be used                                                                           |
 | `-d`  | `--daysToExpiry` | `number` | Allows users to supply an explicit number of days to expiry - if not supplied, then ADO will determine the expiry date                                                   |
 | `-t`  | `--pat`          | `string` | Allows users to supply an explicit Personal Access Token (which must include the Packaging read and write scopes) - if not supplied, will be acquired from the Azure CLI |
+| `-w`  | `--what-if`      |          | Do not write output to user .npmrc file; rather output to terminal                                                                                                       |
 | `-h`  | `--help`         |          | Show help                                                                                                                                                                |
 | `-v`  | `--version`      |          | Show version                                                                                                                                                             |
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ npx -y --registry https://registry.npmjs.org azdo-npm-auth --organization johnny
 
 ## Prerequisites
 
-If you would like `azdo-npm-auth` to acquire a token on your behalf, then it requires that your [Azure DevOps organisation is connected with your Azure account / Microsoft Entra ID](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/connect-organization-to-azure-ad?view=azure-devops). Then, assuming you are authenticated with Azure, it can acquire an Azure DevOps Personal Access Token on your behalf. To authenticate, run `az login`. [If you need to install the Azure CLI, follow these instructions](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli). It is not necessary to run `az login` if you are already authenticated with Azure.
+If you would like `azdo-npm-auth` to acquire a token on your behalf, then it requires that your [Azure DevOps organization is connected with your Azure account / Microsoft Entra ID](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/connect-organization-to-azure-ad?view=azure-devops). Then, assuming you are authenticated with Azure, it can acquire an Azure DevOps Personal Access Token on your behalf. To authenticate, run `az login`. [If you need to install the Azure CLI, follow these instructions](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli). It is not necessary to run `az login` if you are already authenticated with Azure.
 
 If you would like to acquire a PAT token manually and supply it, there is a `--pat` option for that very need.
 

--- a/src/bin/help.test.ts
+++ b/src/bin/help.test.ts
@@ -56,6 +56,10 @@ describe("logHelpText", () => {
 			  ],
 			  [
 			    "
+			  -w | --what-if: If provided, will not write output to to a user .npmrc file; will instead print to stdout",
+			  ],
+			  [
+			    "
 			  -o | --organization (string): The Azure DevOps organization - only required if not parsing from the .npmrc file",
 			  ],
 			  [

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -59,6 +59,7 @@ export async function bin(args: string[]) {
 	prompts.intro(introPrompts);
 
 	const mappedOptions = {
+		whatIf: values["what-if"],
 		pat: values.pat,
 		config: values.config,
 		organization: values.organization,
@@ -87,6 +88,7 @@ export async function bin(args: string[]) {
 	}
 
 	const {
+		whatIf,
 		config,
 		organization,
 		project,
@@ -122,7 +124,7 @@ export async function bin(args: string[]) {
 				: `- organization: ${organization ?? ""}\n- project: ${project ?? ""}\n- feed: ${feed ?? ""}`);
 
 	prompts.log.info(
-		`options:
+		`options:${whatIf ? "\n- what-if" : ""}
 - pat: ${pat ? "supplied" : "[NONE SUPPLIED - WILL ACQUIRE FROM AZURE]"}
 - email: ${email ?? "[NONE SUPPLIED - WILL USE DEFAULT VALUE]"}
 - daysToExpiry: ${daysToExpiry ? daysToExpiry.toLocaleString() : "[NONE SUPPLIED - API WILL DETERMINE EXPIRY]"}
@@ -189,12 +191,16 @@ ${optionsSuffix}`,
 				),
 		);
 
-		await withSpinner(`Writing user .npmrc`, logger, (logger) =>
-			writeNpmrc({
-				npmrc,
-				logger,
-			}),
-		);
+		if (whatIf) {
+			console.log(npmrc);
+		} else {
+			await withSpinner(`Writing user .npmrc`, logger, (logger) => {
+				return writeNpmrc({
+					npmrc,
+					logger,
+				});
+			});
+		}
 
 		prompts.outro(outroPrompts);
 

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -166,7 +166,7 @@ ${optionsSuffix}`,
 			: await withSpinner(`Creating Personal Access Token`, logger, (logger) =>
 					createPat({
 						logger,
-						organisation: parsedProjectNpmrcs[0].organization,
+						organization: parsedProjectNpmrcs[0].organization,
 						daysToExpiry,
 					}),
 				);

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -130,7 +130,7 @@ ${optionsSuffix}`,
 	);
 
 	try {
-		const parsedProjectNpmrc = await withSpinner(
+		const parsedProjectNpmrcs = await withSpinner(
 			projectNpmrcMode === "registry"
 				? `Using supplied registry`
 				: projectNpmrcMode === "parse"
@@ -139,7 +139,7 @@ ${optionsSuffix}`,
 			logger,
 			async (logger) => {
 				return projectNpmrcMode === "registry"
-					? projectNpmrcRegistry({ registry: registry ?? "", logger })
+					? [projectNpmrcRegistry({ registry: registry ?? "", logger })]
 					: projectNpmrcMode === "parse"
 						? await projectNpmrcParse({
 								npmrcPath: config
@@ -147,11 +147,13 @@ ${optionsSuffix}`,
 									: path.resolve(process.cwd(), ".npmrc"),
 								logger,
 							})
-						: projectNpmrcMake({
-								organization: organization ?? "",
-								project,
-								feed: feed ?? "",
-							});
+						: [
+								projectNpmrcMake({
+									organization: organization ?? "",
+									project,
+									feed: feed ?? "",
+								}),
+							];
 			},
 		);
 
@@ -164,7 +166,7 @@ ${optionsSuffix}`,
 			: await withSpinner(`Creating Personal Access Token`, logger, (logger) =>
 					createPat({
 						logger,
-						organisation: parsedProjectNpmrc.organization,
+						organisation: parsedProjectNpmrcs[0].organization,
 						daysToExpiry,
 					}),
 				);
@@ -175,7 +177,7 @@ ${optionsSuffix}`,
 			(logger) =>
 				Promise.resolve(
 					createUserNpmrc({
-						parsedProjectNpmrc,
+						parsedProjectNpmrc: parsedProjectNpmrcs[0],
 						email,
 						logger,
 						pat: personalAccessToken.patToken.token,

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -176,12 +176,16 @@ ${optionsSuffix}`,
 			logger,
 			(logger) =>
 				Promise.resolve(
-					createUserNpmrc({
-						parsedProjectNpmrc: parsedProjectNpmrcs[0],
-						email,
-						logger,
-						pat: personalAccessToken.patToken.token,
-					}),
+					parsedProjectNpmrcs
+						.map((parsedProjectNpmrc) =>
+							createUserNpmrc({
+								parsedProjectNpmrc,
+								email,
+								logger,
+								pat: personalAccessToken.patToken.token,
+							}),
+						)
+						.join("\n"),
 				),
 		);
 

--- a/src/createPat.ts
+++ b/src/createPat.ts
@@ -9,12 +9,12 @@ import { fallbackLogger, type Logger } from "./shared/cli/logger.js";
 
 export async function createPat({
 	logger = fallbackLogger,
-	organisation,
+	organization,
 	daysToExpiry,
 	scope = "vso.packaging",
 }: {
 	logger?: Logger;
-	organisation: string;
+	organization: string;
 	daysToExpiry?: number;
 	scope?: string;
 }): Promise<TokenResult> {
@@ -38,7 +38,7 @@ export async function createPat({
 
 	try {
 		// https://learn.microsoft.com/en-us/rest/api/azure/devops/tokens/pats/create?view=azure-devops-rest-7.1&tabs=HTTP
-		const url = `https://vssps.dev.azure.com/${organisation}/_apis/tokens/pats?api-version=7.1-preview.1`;
+		const url = `https://vssps.dev.azure.com/${organization}/_apis/tokens/pats?api-version=7.1-preview.1`;
 		const data = {
 			displayName: `made by azdo-npm-auth at: ${new Date().toISOString()}`,
 			scope,
@@ -87,12 +87,12 @@ export async function createPat({
 ${error instanceof Error ? error.message : JSON.stringify(error)}
 
 Please ensure that:
-1. Your Azure DevOps organisation is connected with your Azure account / Microsoft Entra ID
+1. Your Azure DevOps organization is connected with your Azure account / Microsoft Entra ID
 2. You are logged into the Azure CLI (use \`az login\` to log in)
 
 If you continue to have issues, consider creating a Personal Access Token with the Packaging read and write scopes manually in Azure DevOps and providing it to \`azdo-npm-auth\` using the \`--pat\` option.
 
-You can create a PAT here: https://dev.azure.com/${organisation}/_usersSettings/tokens`;
+You can create a PAT here: https://dev.azure.com/${organization}/_usersSettings/tokens`;
 		throw new Error(errorMessage);
 	}
 }

--- a/src/createUserNpmrc.test.ts
+++ b/src/createUserNpmrc.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import type { ParsedProjectNpmrc } from "./types.js";
+
+import { createUserNpmrc } from "./createUserNpmrc.js";
+
+describe("createUserNpmrc", () => {
+	it("creates a properly formatted user .npmrc with organization feed", () => {
+		// Arrange
+		const parsedProjectNpmrc: ParsedProjectNpmrc = {
+			scope: undefined,
+			organization: "johnnyreilly",
+			urlWithoutRegistryAtEnd:
+				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
+			urlWithoutRegistryAtStart:
+				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+		};
+		const pat = "test-pat-token";
+
+		// Act
+		const result = createUserNpmrc({
+			parsedProjectNpmrc,
+			pat,
+		});
+
+		// Assert
+		expect(result).toMatchInlineSnapshot(`
+			"; begin auth token
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/:username=johnnyreilly
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/:_password=dGVzdC1wYXQtdG9rZW4=
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/:email=npm requires email to be set but doesn't use the value
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/:username=johnnyreilly
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/:_password=dGVzdC1wYXQtdG9rZW4=
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/:email=npm requires email to be set but doesn't use the value
+			; end auth token
+			"
+		`);
+	});
+
+	it("creates a user .npmrc with project-specific feed", () => {
+		// Arrange
+		const parsedProjectNpmrc: ParsedProjectNpmrc = {
+			scope: undefined,
+			organization: "johnnyreilly",
+			urlWithoutRegistryAtEnd:
+				"//pkgs.dev.azure.com/johnnyreilly/azure-static-web-apps/_packaging/npmrc-script-demo/npm/",
+			urlWithoutRegistryAtStart:
+				"//pkgs.dev.azure.com/johnnyreilly/azure-static-web-apps/_packaging/npmrc-script-demo/npm/registry/",
+		};
+		const pat = "test-pat-token";
+
+		// Act
+		const result = createUserNpmrc({
+			parsedProjectNpmrc,
+			pat,
+		});
+
+		// Assert
+		expect(result).toMatchInlineSnapshot(`
+			"; begin auth token
+			//pkgs.dev.azure.com/johnnyreilly/azure-static-web-apps/_packaging/npmrc-script-demo/npm/registry/:username=johnnyreilly
+			//pkgs.dev.azure.com/johnnyreilly/azure-static-web-apps/_packaging/npmrc-script-demo/npm/registry/:_password=dGVzdC1wYXQtdG9rZW4=
+			//pkgs.dev.azure.com/johnnyreilly/azure-static-web-apps/_packaging/npmrc-script-demo/npm/registry/:email=npm requires email to be set but doesn't use the value
+			//pkgs.dev.azure.com/johnnyreilly/azure-static-web-apps/_packaging/npmrc-script-demo/npm/:username=johnnyreilly
+			//pkgs.dev.azure.com/johnnyreilly/azure-static-web-apps/_packaging/npmrc-script-demo/npm/:_password=dGVzdC1wYXQtdG9rZW4=
+			//pkgs.dev.azure.com/johnnyreilly/azure-static-web-apps/_packaging/npmrc-script-demo/npm/:email=npm requires email to be set but doesn't use the value
+			; end auth token
+			"
+		`);
+	});
+
+	it("uses custom email when provided", () => {
+		// Arrange
+		const parsedProjectNpmrc: ParsedProjectNpmrc = {
+			scope: undefined,
+			organization: "johnnyreilly",
+			urlWithoutRegistryAtEnd:
+				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
+			urlWithoutRegistryAtStart:
+				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+		};
+		const pat = "test-pat-token";
+		const customEmail = "test@example.com";
+
+		// Act
+		const result = createUserNpmrc({
+			parsedProjectNpmrc,
+			pat,
+			email: customEmail,
+		});
+
+		// Assert
+		expect(result).toMatchInlineSnapshot(`
+			"; begin auth token
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/:username=johnnyreilly
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/:_password=dGVzdC1wYXQtdG9rZW4=
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/:email=test@example.com
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/:username=johnnyreilly
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/:_password=dGVzdC1wYXQtdG9rZW4=
+			//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/:email=test@example.com
+			; end auth token
+			"
+		`);
+	});
+
+	it("handles parsed project npmrc with a scope property", () => {
+		// Arrange
+		const parsedProjectNpmrc: ParsedProjectNpmrc = {
+			organization: "johnnyreilly",
+			scope: "@myorg",
+			urlWithoutRegistryAtEnd:
+				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
+			urlWithoutRegistryAtStart:
+				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+		};
+		const pat = "test-pat-token";
+
+		// Act
+		const result = createUserNpmrc({
+			parsedProjectNpmrc,
+			pat,
+		});
+
+		// Assert
+		// Verify the scope doesn't affect the .npmrc format
+		expect(result).toContain("; begin auth token");
+		expect(result).toContain(
+			"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/:username=johnnyreilly",
+		);
+		expect(result).toContain(
+			"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/:username=johnnyreilly",
+		);
+
+		// Even though parsedProjectNpmrc has a scope property, it should not appear in the .npmrc output
+		// as it's not used by the createUserNpmrc function
+		const base64EncodedPAT = Buffer.from(pat).toString("base64");
+		const expectedNpmrcWithScope = `; begin auth token
+//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/:username=johnnyreilly
+//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/:_password=${base64EncodedPAT}
+//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/:email=npm requires email to be set but doesn't use the value
+//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/:username=johnnyreilly
+//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/:_password=${base64EncodedPAT}
+//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/:email=npm requires email to be set but doesn't use the value
+; end auth token
+`;
+		expect(result).toEqual(expectedNpmrcWithScope);
+	});
+});

--- a/src/createUserNpmrc.ts
+++ b/src/createUserNpmrc.ts
@@ -26,17 +26,14 @@ export function createUserNpmrc({
 }): string {
 	const base64EncodedPAT = Buffer.from(pat).toString("base64");
 
-	const {
-		urlWithoutRegistryAtEnd,
-		urlWithoutRegistryAtStart,
-		organization: organisation,
-	} = parsedProjectNpmrc;
+	const { urlWithoutRegistryAtEnd, urlWithoutRegistryAtStart, organization } =
+		parsedProjectNpmrc;
 
 	const npmrc = `; begin auth token
-${urlWithoutRegistryAtStart}:username=${organisation}
+${urlWithoutRegistryAtStart}:username=${organization}
 ${urlWithoutRegistryAtStart}:_password=${base64EncodedPAT}
 ${urlWithoutRegistryAtStart}:email=${email}
-${urlWithoutRegistryAtEnd}:username=${organisation}
+${urlWithoutRegistryAtEnd}:username=${organization}
 ${urlWithoutRegistryAtEnd}:_password=${base64EncodedPAT}
 ${urlWithoutRegistryAtEnd}:email=${email}
 ; end auth token

--- a/src/projectNpmrcMake.test.ts
+++ b/src/projectNpmrcMake.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { projectNpmrcMake } from "./projectNpmrcMake.js";
 
 describe("projectNpmrcMake", () => {
-	it("given no project it constructs an organisation feed ParsedProjectNpmrc", () => {
+	it("given no project it constructs an organization feed ParsedProjectNpmrc", () => {
 		const result = projectNpmrcMake({
 			organization: "johnnyreilly",
 			feed: "npmrc-script-organization",

--- a/src/projectNpmrcMake.ts
+++ b/src/projectNpmrcMake.ts
@@ -34,5 +34,10 @@ export function projectNpmrcMake({
 - urlWithoutRegistryAtStart: ${urlWithoutRegistryAtStart}
 - urlWithoutRegistryAtEnd: ${urlWithoutRegistryAtEnd}`);
 
-	return { urlWithoutRegistryAtStart, urlWithoutRegistryAtEnd, organization };
+	return {
+		urlWithoutRegistryAtStart,
+		urlWithoutRegistryAtEnd,
+		organization,
+		scope: undefined, // scope is not supported in this case (yet)
+	};
 }

--- a/src/projectNpmrcParse.test.ts
+++ b/src/projectNpmrcParse.test.ts
@@ -48,8 +48,7 @@ always-auth=true`);
 		]);
 	});
 
-	// introduce later
-	it.skip("outputs the expected structure on successful parse of multiple organizations and combined organization and project feeds", async () => {
+	it("outputs the expected structure on successful parse of multiple organizations and combined organization and project feeds", async () => {
 		mockReadFile.mockResolvedValue(`engine-strict=true
 node-options=--max-old-space-size=8192
 
@@ -64,10 +63,27 @@ always-auth=true`);
 		expect(result).toEqual([
 			{
 				organization: "johnnyreilly",
+				scope: undefined,
 				urlWithoutRegistryAtEnd:
 					"//pkgs.dev.azure.com/johnnyreilly/_packaging/organization-feed-name/npm/",
 				urlWithoutRegistryAtStart:
 					"//pkgs.dev.azure.com/johnnyreilly/_packaging/organization-feed-name/npm/registry/",
+			},
+			{
+				organization: "johnnyreilly",
+				scope: "@myorg",
+				urlWithoutRegistryAtEnd:
+					"//pkgs.dev.azure.com/johnnyreilly/project-name1/_packaging/project-feed-name/npm/",
+				urlWithoutRegistryAtStart:
+					"//pkgs.dev.azure.com/johnnyreilly/project-name1/_packaging/project-feed-name/npm/registry/",
+			},
+			{
+				organization: "johnnyreilly",
+				scope: "@myorg-other",
+				urlWithoutRegistryAtEnd:
+					"//pkgs.dev.azure.com/johnnyreilly/another-project-name/_packaging/different-project-feed-name/npm/",
+				urlWithoutRegistryAtStart:
+					"//pkgs.dev.azure.com/johnnyreilly/another-project-name/_packaging/different-project-feed-name/npm/registry/",
 			},
 		]);
 	});

--- a/src/projectNpmrcParse.test.ts
+++ b/src/projectNpmrcParse.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { projectNpmrcParse } from "./projectNpmrcParse.js";
+import { parseNpmrcContent, projectNpmrcParse } from "./projectNpmrcParse.js";
 
 const mockReadFile = vi.fn();
 
@@ -43,6 +43,30 @@ always-auth=true`);
 		});
 	});
 
+	// introduce later
+	it.skip("outputs the expected structure on successful parse of multiple organisations and combined organisation and project feeds", async () => {
+		mockReadFile.mockResolvedValue(`engine-strict=true
+node-options=--max-old-space-size=8192
+
+registry=https://pkgs.dev.azure.com/johnnyreilly/_packaging/organization-feed-name/npm/registry/
+@myorg:registry=https://pkgs.dev.azure.com/johnnyreilly/project-name1/_packaging/project-feed-name/npm/registry/
+@myorg-other:registry=https://pkgs.dev.azure.com/johnnyreilly/another-project-name/_packaging/different-project-feed-name/npm/registry/
+                        
+always-auth=true`);
+		const result = await projectNpmrcParse({
+			npmrcPath: "/home/john/code/github/azdo-npm-auth/.npmrc",
+		});
+		expect(result).toEqual([
+			{
+				organization: "johnnyreilly",
+				urlWithoutRegistryAtEnd:
+					"//pkgs.dev.azure.com/johnnyreilly/_packaging/organization-feed-name/npm/",
+				urlWithoutRegistryAtStart:
+					"//pkgs.dev.azure.com/johnnyreilly/_packaging/organization-feed-name/npm/registry/",
+			},
+		]);
+	});
+
 	// I haven't worked out whether I want to support this yet
 	it.skip("outputs the expected structure when expected last `/` is not there", async () => {
 		mockReadFile.mockResolvedValue(`registry=https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry 
@@ -67,5 +91,36 @@ always-auth=true`);
 				npmrcPath: "/home/john/code/github/azdo-npm-auth/.npmrc",
 			}),
 		).rejects.toThrowError("Unable to extract information from project .npmrc");
+	});
+});
+
+describe("parseNpmrcContent", () => {
+	it("outputs the expected registry on successful parse", () => {
+		const result =
+			parseNpmrcContent(`registry=https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/ 
+                        
+always-auth=true`);
+		expect(result).toEqual({
+			registry:
+				"https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+		});
+	});
+
+	it("outputs the expected registry on successful parse with org scope", () => {
+		const result =
+			parseNpmrcContent(`@myorg:registry=https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/ 
+                        
+always-auth=true`);
+		expect(result).toEqual({
+			registry:
+				"https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+			scope: "@myorg",
+		});
+	});
+
+	it("errors on invalid content", () => {
+		expect(() => parseNpmrcContent(`stuff`)).toThrowError(
+			"Unable to extract information from project .npmrc",
+		);
 	});
 });

--- a/src/projectNpmrcParse.test.ts
+++ b/src/projectNpmrcParse.test.ts
@@ -18,13 +18,15 @@ always-auth=true`);
 		const result = await projectNpmrcParse({
 			npmrcPath: "/home/john/code/github/azdo-npm-auth/.npmrc",
 		});
-		expect(result).toEqual({
-			organization: "johnnyreilly",
-			urlWithoutRegistryAtEnd:
-				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
-			urlWithoutRegistryAtStart:
-				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
-		});
+		expect(result).toEqual([
+			{
+				organization: "johnnyreilly",
+				urlWithoutRegistryAtEnd:
+					"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
+				urlWithoutRegistryAtStart:
+					"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+			},
+		]);
 	});
 
 	it("outputs the expected structure on successful parse with org scope", async () => {
@@ -34,14 +36,16 @@ always-auth=true`);
 		const result = await projectNpmrcParse({
 			npmrcPath: "/home/john/code/github/azdo-npm-auth/.npmrc",
 		});
-		expect(result).toEqual({
-			organization: "johnnyreilly",
-			scope: "@myorg",
-			urlWithoutRegistryAtEnd:
-				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
-			urlWithoutRegistryAtStart:
-				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
-		});
+		expect(result).toEqual([
+			{
+				organization: "johnnyreilly",
+				scope: "@myorg",
+				urlWithoutRegistryAtEnd:
+					"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
+				urlWithoutRegistryAtStart:
+					"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+			},
+		]);
 	});
 
 	// introduce later
@@ -101,10 +105,12 @@ describe("parseNpmrcContent", () => {
 			parseNpmrcContent(`registry=https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/ 
                         
 always-auth=true`);
-		expect(result).toEqual({
-			registry:
-				"https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
-		});
+		expect(result).toEqual([
+			{
+				registry:
+					"https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+			},
+		]);
 	});
 
 	it("outputs the expected registry on successful parse with org scope", () => {
@@ -112,11 +118,13 @@ always-auth=true`);
 			parseNpmrcContent(`@myorg:registry=https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/ 
                         
 always-auth=true`);
-		expect(result).toEqual({
-			registry:
-				"https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
-			scope: "@myorg",
-		});
+		expect(result).toEqual([
+			{
+				registry:
+					"https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/",
+				scope: "@myorg",
+			},
+		]);
 	});
 
 	it("errors on invalid content", () => {

--- a/src/projectNpmrcParse.test.ts
+++ b/src/projectNpmrcParse.test.ts
@@ -49,7 +49,7 @@ always-auth=true`);
 	});
 
 	// introduce later
-	it.skip("outputs the expected structure on successful parse of multiple organisations and combined organisation and project feeds", async () => {
+	it.skip("outputs the expected structure on successful parse of multiple organizations and combined organization and project feeds", async () => {
 		mockReadFile.mockResolvedValue(`engine-strict=true
 node-options=--max-old-space-size=8192
 

--- a/src/projectNpmrcParse.test.ts
+++ b/src/projectNpmrcParse.test.ts
@@ -36,6 +36,7 @@ always-auth=true`);
 		});
 		expect(result).toEqual({
 			organization: "johnnyreilly",
+			scope: "@myorg",
 			urlWithoutRegistryAtEnd:
 				"//pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/",
 			urlWithoutRegistryAtStart:

--- a/src/projectNpmrcParse.ts
+++ b/src/projectNpmrcParse.ts
@@ -1,6 +1,6 @@
 import type { ParsedProjectNpmrc } from "./types.js";
 
-import { makeFromRegistry } from "./projectNpmrcShared.js";
+import { makeParsedProjectNpmrcFromRegistry } from "./projectNpmrcShared.js";
 import { fallbackLogger, type Logger } from "./shared/cli/logger.js";
 import { readFileSafe } from "./shared/readFileSafe.js";
 
@@ -24,7 +24,7 @@ export async function projectNpmrcParse({
 
 	const { registry, scope } = parseNpmrcContent(npmrcContents);
 
-	return makeFromRegistry({ registry, scope, logger });
+	return makeParsedProjectNpmrcFromRegistry({ registry, scope, logger });
 }
 
 export function parseNpmrcContent(npmrcContents: string) {

--- a/src/projectNpmrcRegistry.ts
+++ b/src/projectNpmrcRegistry.ts
@@ -1,6 +1,6 @@
 import type { ParsedProjectNpmrc } from "./types.js";
 
-import { makeFromRegistry } from "./projectNpmrcShared.js";
+import { makeParsedProjectNpmrcFromRegistry } from "./projectNpmrcShared.js";
 import { fallbackLogger, type Logger } from "./shared/cli/logger.js";
 
 /**
@@ -15,5 +15,5 @@ export function projectNpmrcRegistry({
 }): ParsedProjectNpmrc {
 	logger.info(`Parsing from registry: ${registry}`);
 
-	return makeFromRegistry({ registry, logger });
+	return makeParsedProjectNpmrcFromRegistry({ registry, logger });
 }

--- a/src/projectNpmrcShared.ts
+++ b/src/projectNpmrcShared.ts
@@ -2,9 +2,11 @@ import type { Logger } from "./shared/cli/logger.js";
 
 export function makeFromRegistry({
 	registry,
+	scope,
 	logger,
 }: {
 	registry: string;
+	scope?: string;
 	logger: Logger;
 }) {
 	if (!registry.startsWith("https:")) {
@@ -18,16 +20,17 @@ export function makeFromRegistry({
 	// extract the organisation which we will use as the username
 	// not sure why this is the case, but this is the behaviour
 	// defined in ADO
-	const organisation = urlWithoutRegistryAtEnd.split("/")[3];
+	const organization = urlWithoutRegistryAtEnd.split("/")[3];
 
-	logger.info(`Parsed: 
-- organisation: ${organisation}
+	logger.info(`Parsed:
+- scope: ${scope ?? ""}
+- organisation: ${organization}
 - urlWithoutRegistryAtStart: ${urlWithoutRegistryAtStart}
 - urlWithoutRegistryAtEnd: ${urlWithoutRegistryAtEnd}`);
 
 	return {
 		urlWithoutRegistryAtStart,
 		urlWithoutRegistryAtEnd,
-		organization: organisation,
+		organization,
 	};
 }

--- a/src/projectNpmrcShared.ts
+++ b/src/projectNpmrcShared.ts
@@ -1,14 +1,17 @@
 import type { Logger } from "./shared/cli/logger.js";
+import type { ParsedProjectNpmrc } from "./types.js";
 
-export function makeFromRegistry({
+export function makeParsedProjectNpmrcFromRegistry({
 	registry,
 	scope,
 	logger,
 }: {
+	/** eg https://pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/ */
 	registry: string;
+	/** eg @myorg */
 	scope?: string;
 	logger: Logger;
-}) {
+}): ParsedProjectNpmrc {
 	if (!registry.startsWith("https:")) {
 		throw new Error("Unable to extract information");
 	}
@@ -32,5 +35,6 @@ export function makeFromRegistry({
 		urlWithoutRegistryAtStart,
 		urlWithoutRegistryAtEnd,
 		organization,
+		scope,
 	};
 }

--- a/src/projectNpmrcShared.ts
+++ b/src/projectNpmrcShared.ts
@@ -20,14 +20,14 @@ export function makeParsedProjectNpmrcFromRegistry({
 		/registry\/$/,
 		"",
 	);
-	// extract the organisation which we will use as the username
+	// extract the organization which we will use as the username
 	// not sure why this is the case, but this is the behaviour
 	// defined in ADO
 	const organization = urlWithoutRegistryAtEnd.split("/")[3];
 
 	logger.info(`Parsed:
 - scope: ${scope ?? ""}
-- organisation: ${organization}
+- organization: ${organization}
 - urlWithoutRegistryAtStart: ${urlWithoutRegistryAtStart}
 - urlWithoutRegistryAtEnd: ${urlWithoutRegistryAtEnd}`);
 

--- a/src/shared/options/args.ts
+++ b/src/shared/options/args.ts
@@ -4,6 +4,11 @@ export const options = {
 		type: "string",
 	},
 
+	"what-if": {
+		type: "boolean",
+		short: "w",
+	},
+
 	organization: {
 		short: "o",
 		type: "string",
@@ -67,6 +72,13 @@ export const allArgOptions: Record<ValidOption, DocOption> = {
 		...options.config,
 		description:
 			"The location of the .npmrc file. Defaults to current directory",
+		docsSection: "optional",
+	},
+
+	"what-if": {
+		...options["what-if"],
+		description:
+			"If provided, will not write output to to a user .npmrc file; will instead print to stdout",
 		docsSection: "optional",
 	},
 

--- a/src/shared/options/optionsSchema.ts
+++ b/src/shared/options/optionsSchema.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 export const optionsSchema = z.object({
+	whatIf: z.boolean().optional(),
+
 	pat: z.string().optional(),
 	config: z.string().optional(),
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,8 @@ export interface TokenResult {
 export interface ParsedProjectNpmrc {
 	/** eg johnnyreilly */
 	organization: string;
+	/** eg @myorg */
+	scope: string | undefined;
 	/** eg //pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/ */
 	urlWithoutRegistryAtEnd: string;
 	/** eg //pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/ */

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,10 @@ export interface TokenResult {
 }
 
 export interface ParsedProjectNpmrc {
+	/** eg johnnyreilly */
 	organization: string;
+	/** eg //pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/ */
 	urlWithoutRegistryAtEnd: string;
+	/** eg //pkgs.dev.azure.com/johnnyreilly/_packaging/npmrc-script-organization/npm/registry/ */
 	urlWithoutRegistryAtStart: string;
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to azdo-npm-auth! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #32
- [x] That issue was marked as [`status: accepting prs`](https://github.com/johnnyreilly/azdo-npm-auth/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/johnnyreilly/azdo-npm-auth/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR amends `azdo-npm-auth` to cater for a number of registry entries in the same project `.npmrc` file.  Something like this:

```npmrc
registry=https://pkgs.dev.azure.com/johnnyreilly/_packaging/organization-feed-name/npm/registry/
@myorg:registry=https://pkgs.dev.azure.com/johnnyreilly/project-name1/_packaging/project-feed-name/npm/registry/
@myorg-other:registry=https://pkgs.dev.azure.com/johnnyreilly/another-project-name/_packaging/different-project-feed-name/npm/registry/
                        
always-auth=true
```